### PR TITLE
fix(price-history): guard against undefined property access

### DIFF
--- a/src/modules/tokenomics/components/cards/PriceHistoryCard.tsx
+++ b/src/modules/tokenomics/components/cards/PriceHistoryCard.tsx
@@ -53,7 +53,7 @@ export function PriceHistoryCard({
         <InfoCard
           title="Current Price"
           isLoading={isLoading}
-          value={priceHistoryData?.priceHistory[priceHistoryData.priceHistory.length - 1].price}
+          value={priceHistoryData?.priceHistory?.at(-1)?.price}
           valuePrefix="$"
           themeColors={secondaryThemeColors}
         />
@@ -69,7 +69,7 @@ export function PriceHistoryCard({
         <InfoCard
           title="All-Time Low"
           isLoading={isLoading}
-          value={priceHistoryData?.allTimeLow.toFixed(4)}
+          value={priceHistoryData?.allTimeLow?.toFixed(4)}
           valuePrefix="$"
           themeColors={secondaryThemeColors}
         />


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading 'price')` crash in PriceHistoryCard
- Use safe optional chaining (`?.at(-1)?.price`) instead of unsafe array index access
- Also fix unguarded `.toFixed()` call on potentially undefined `allTimeLow`

## Test plan
- [ ] Load dashboard when price history API returns empty data
- [ ] Load dashboard when price history API returns valid data
- [ ] Verify Current Price, All-Time High, and All-Time Low cards render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)